### PR TITLE
Se puso Pulso como campo requerido en form preclinico

### DIFF
--- a/openmrs/apps/registration/app.json
+++ b/openmrs/apps/registration/app.json
@@ -292,6 +292,9 @@
                 },
                 "defaults":{
                     "FHS": "Present"
+                },
+                "Pulse": {
+                    "required": true
                 }
             },
             "fieldValidation" : {


### PR DESCRIPTION
Ya no se puede submit el form de preclinico vacio.